### PR TITLE
Add support for jquery-pjax

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ In your `application.js.coffee` (or just JS):
 #= require nprogress-turbolinks
 ```
 
-The `nprogress-turbolinks` is required only if you use turbolinks. Otherwise,
+The `nprogress-turbolinks` is required only if you use turbolinks. Using pjax
+rather than turbolinks? Simply require `nprogress-pjax` instead. Otherwise,
 you will have to deal with show/hide the progress by your own.
 
 Also, into your `application.css.scss` file:

--- a/vendor/assets/javascripts/nprogress-pjax.js
+++ b/vendor/assets/javascripts/nprogress-pjax.js
@@ -1,0 +1,4 @@
+$(function() {
+  $(document).on('pjax:send',     function() { NProgress.start(); });
+  $(document).on('pjax:complete', function() { NProgress.done();  });
+});


### PR DESCRIPTION
Add `nprogress-pjax.js`, which triggers an `NProgress.start()` on the
`pjax:send` event, as well as an `NProgress.done()` on the
`pjax:complete` event. These two events are only fired when an actual
AJAX request is made, not when a cached page is loaded by the browser.
No event to call `NProgress.remove()` should be necessary.

Signed-off-by: David Celis me@davidcel.is
