### PR TITLE
instant complete when page loaded

### DIFF
--- a/app/assets/javascripts/nprogress.js
+++ b/app/assets/javascripts/nprogress.js
@@ -82,7 +82,7 @@
             NProgress.remove();
             next();
           }, 0);
-        }, speed);
+        }, 0);
       } else {
         setTimeout(next, speed);
       }


### PR DESCRIPTION
Users must not wait additional speed \* 2 (400ms) after page is loaded. In our project we also fade all page, so it was look as big problem.
