### PR TITLE
Bump progress to 70% on page:receive

### DIFF
--- a/app/assets/javascripts/nprogress-turbolinks.js
+++ b/app/assets/javascripts/nprogress-turbolinks.js
@@ -1,6 +1,6 @@
 $(function() {
   $(document).on('page:fetch',   function() { NProgress.start();  });
-  $(document).on('page:receive', function() { NProgress.set(0.7); })
+  $(document).on('page:receive', function() { NProgress.set(0.7); });
   $(document).on('page:change',  function() { NProgress.done();   });
   $(document).on('page:restore', function() { NProgress.remove(); });
 });


### PR DESCRIPTION
Currently I feel like only combining `NProgress.start()` and `NProgress.done()` feels a bit unauthentic. I think that bumping up to 70% on `page:receive` gives the progress bar a much more authentic feel. Also much more accurately indicates how quickly a page is loading, rather than letting NProgress automatically trickle regardless of request speed.
