### PR TITLE
Use jQuery function rather than the '$' shortcut, to increase compatability

### DIFF
--- a/app/assets/javascripts/nprogress-ajax.js
+++ b/app/assets/javascripts/nprogress-ajax.js
@@ -1,4 +1,4 @@
-$(function() {
-  $(document).on('ajaxStart', function() { NProgress.start(); });
-  $(document).on('ajaxStop',  function() { NProgress.done();  });
+jQuery(function() {
+  jQuery(document).on('ajaxStart', function() { NProgress.start(); });
+  jQuery(document).on('ajaxStop',  function() { NProgress.done();  });
 });


### PR DESCRIPTION
In the legacy app I'm working on, jQuery co-exists with Prototype. So jQuery is short-cutted as `$j()` rather than `$()`, which caused this script to not work.

If we use `jQuery()` instead, it works for everyone!