### PR TITLE
Disable TurboLinks.ProgressBar if it exists

### DIFF
--- a/app/assets/javascripts/nprogress-turbolinks.js
+++ b/app/assets/javascripts/nprogress-turbolinks.js
@@ -1,4 +1,5 @@
 jQuery(function() {
+  if (Turbolinks.ProgressBar) { Turbolinks.ProgressBar.disable(); }
   jQuery(document).on('page:fetch',   function() { NProgress.start();  });
   jQuery(document).on('page:receive', function() { NProgress.set(0.7); });
   jQuery(document).on('page:change',  function() { NProgress.done();   });


### PR DESCRIPTION
This PR puts the fix discussed in issue #32 into action. This was discussed with @metaskills, so I'm not stealing his thunder :zap: