### PR TITLE
Add support for Turbolinks 5

### DIFF
--- a/app/assets/javascripts/nprogress-turbolinks-classic.js
+++ b/app/assets/javascripts/nprogress-turbolinks-classic.js
@@ -1,0 +1,7 @@
+jQuery(function() {
+  if (Turbolinks.ProgressBar) { Turbolinks.ProgressBar.disable(); }
+  jQuery(document).on('page:fetch',   function() { NProgress.start();  });
+  jQuery(document).on('page:receive', function() { NProgress.set(0.7); });
+  jQuery(document).on('page:change',  function() { NProgress.done();   });
+  jQuery(document).on('page:restore', function() { NProgress.remove(); });
+});

--- a/app/assets/javascripts/nprogress-turbolinks.js
+++ b/app/assets/javascripts/nprogress-turbolinks.js
@@ -1,7 +1,6 @@
 jQuery(function() {
-  if (Turbolinks.ProgressBar) { Turbolinks.ProgressBar.disable(); }
-  jQuery(document).on('page:fetch',   function() { NProgress.start();  });
-  jQuery(document).on('page:receive', function() { NProgress.set(0.7); });
-  jQuery(document).on('page:change',  function() { NProgress.done();   });
-  jQuery(document).on('page:restore', function() { NProgress.remove(); });
+  jQuery(document).on('turbolinks:visit',         function() { NProgress.start();  });
+  jQuery(document).on('turbolinks:request-start', function() { NProgress.set(0.7); });
+  jQuery(document).on('turbolinks:request-end',   function() { NProgress.done();   });
+  jQuery(document).on('turbolinks:load',          function() { NProgress.remove(); });
 });

--- a/app/assets/stylesheets/nprogress-turbolinks.css
+++ b/app/assets/stylesheets/nprogress-turbolinks.css
@@ -1,0 +1,1 @@
+.turbolinks-progress-bar { visibility: hidden; }


### PR DESCRIPTION
As Turbolinks 5 is getting out soon, I would like to propose this breaking change to your gem.

They [renamed every events](https://github.com/turbolinks/turbolinks/wiki/Turbolinks-5-FAQ#should-i-use-turbolinks-5-or-turbolinks-classic), and apparently, `Turbolinks.ProgressBar.disable()` [disappeared](https://github.com/turbolinks/turbolinks/blob/master/src/turbolinks/progress_bar.coffee).
So I moved `nprogress-turbolinks.js` to `nprogress-turbolinks-classic.js` and replace events name in `nprogress-turbolinks.js`, to make it compatible with the version 5.

To make the native progress bar disappear, they said [you've to hide it in CSS](https://github.com/turbolinks/turbolinks#displaying-progress). So I also add `nprogress-turbolinks.css` to the repository.

I'll write the documentation when we're sure about incoming changes.