### PR TITLE
Fix for turbolinks 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ Also, into your `application.css.scss` file:
 ```scss
 *= require nprogress
 *= require nprogress-bootstrap
+*= require nprogress-turbolinks5
 ```
 
 The `nprogress-bootstrap` is required if you use bootstrap and have a fixed
 toolbar or anything else. tl;dr: if the console shows no errors, but the
 progress doesn't appear, try this.
+
+The `nprogress-turbolinks5` is required if you use turbolinks 5 and does not
+want the default turbolinks progress to show up.
 
 ### Angular.js support
 

--- a/app/assets/javascripts/nprogress-turbolinks.js
+++ b/app/assets/javascripts/nprogress-turbolinks.js
@@ -1,5 +1,4 @@
 jQuery(function() {
-  if (Turbolinks.ProgressBar) { Turbolinks.ProgressBar.disable(); }
   jQuery(document).on('page:fetch turbolinks:request-start', function() {
     NProgress.start();
   });

--- a/app/assets/stylesheets/nprogress-turbolinks5.css
+++ b/app/assets/stylesheets/nprogress-turbolinks5.css
@@ -1,0 +1,3 @@
+.turbolinks-progress-bar {
+  visibility: hidden;
+}


### PR DESCRIPTION
This PR attempts to fix this gem not working with Turbolinks 5.

The issue happens because `Turbolinks.ProgressBar.disable();` was introduced to prevent the progress bar from being showed on Turbolinks 3, but since Turbolinks 3 was never properly released (it is only available on the github repo [turbolinks/turbolinks-classic](https://github.com/turbolinks/turbolinks-classic) and it appears it won't have a final release: [turbolinks#wiki](https://github.com/turbolinks/turbolinks/wiki/Turbolinks-5-FAQ#why-is-it-called-turbolinks-5-what-happened-to-versions-3-and-4)) I believe it is safe to remove this line from the `nprogress-turbolinks.js` file.

I have also added an `nprogress-turbolinks5.css` file that should be included when using Turbolinks 5 and disables the default progress bar. I'm not sure if this is the best way we could achieve this for this Gem, but adding that specific CSS is currently the only supported way of disabling it according to their repo ([turbolinks/turbolinks#displaying-progress](https://github.com/turbolinks/turbolinks#displaying-progress)).