### PR TITLE
Use new turbolinks v5 events

### DIFF
--- a/app/assets/javascripts/nprogress-turbolinks.js
+++ b/app/assets/javascripts/nprogress-turbolinks.js
@@ -1,14 +1,10 @@
 jQuery(function() {
-  jQuery(document).on('page:fetch turbolinks:request-start', function() {
-    NProgress.start();
-  });
-  jQuery(document).on('page:receive turbolinks:request-end', function() {
-    NProgress.set(0.7);
-  });
-  jQuery(document).on('page:change turbolinks:load', function() {
-    NProgress.done();
-  });
-  jQuery(document).on('page:restore turbolinks:request-end turbolinks:before-cache', function() {
-    NProgress.remove();
-  });
+  jQuery(document)
+    .on('turbolinks:click', function() {
+        NProgress.start();
+    })
+    .on('turbolinks:render', function() {
+        NProgress.done();
+        NProgress.remove();
+    });
 });


### PR DESCRIPTION
Update turblinks v5 events, as recommended by nprogress (https://github.com/rstacruz/nprogress/issues/8#issuecomment-239107109)
I've tested both versions. This gives better UX, imo. There is no delay between clicking a link, and the loading bar appearing, even on really slow connections.